### PR TITLE
Add expired date to the expired exception.

### DIFF
--- a/resources/translations/en/messages.php
+++ b/resources/translations/en/messages.php
@@ -11,7 +11,7 @@ return [
     |
     */
 
-    'expired' => 'The invite code :CODE has expired.',
+    'expired' => 'The invite code :CODE has expired, expired on :expired.',
     'invalid' => 'The invite code :CODE is invalid.',
     'maxed' => 'The invite code :CODE has already been used the maximum number of times.',
     'restricted' => 'The invite code :CODE belongs to another user.',

--- a/src/Doorman.php
+++ b/src/Doorman.php
@@ -82,7 +82,7 @@ class Doorman
         }
 
         if ($invite->hasExpired()) {
-            throw new ExpiredInviteCode(trans('doorman::messages.expired', [ 'code' => $invite->code ]));
+            throw ExpiredInviteCode::forInvite($invite);
         }
 
         if ($invite->isRestricted() && !$invite->isRestrictedFor($email)) {

--- a/src/Exceptions/ExpiredInviteCode.php
+++ b/src/Exceptions/ExpiredInviteCode.php
@@ -2,7 +2,17 @@
 
 namespace Clarkeash\Doorman\Exceptions;
 
+use Clarkeash\Doorman\Models\Invite;
+
 class ExpiredInviteCode extends DoormanException
 {
+    const DATE_FORMAT = 'Y-m-d H:i';
 
+    public static function forInvite(Invite $invite): ExpiredInviteCode
+    {
+        return new self(trans('doorman::messages.expired', [
+            'code' => $invite->code,
+            'expired' => $invite->expires()->format(self::DATE_FORMAT),
+        ]));
+    }
 }

--- a/src/Models/Invite.php
+++ b/src/Models/Invite.php
@@ -30,6 +30,16 @@ class Invite extends Model
     }
 
     /**
+     * Get the expiry time.
+     *
+     * @return \DateTimeImmutable
+     */
+    public function expires()
+    {
+        return \DateTimeImmutable::createFromMutable($this->valid_until);
+    }
+
+    /**
      * Is the invite full.
      *
      * @return bool

--- a/tests/Feature/RedeemInvitesTest.php
+++ b/tests/Feature/RedeemInvitesTest.php
@@ -3,6 +3,7 @@
 namespace Clarkeash\Doorman\Test\Feature;
 
 use Carbon\Carbon;
+use Clarkeash\Doorman\Exceptions\ExpiredInviteCode;
 use Clarkeash\Doorman\Models\Invite;
 use Doorman;
 use Clarkeash\Doorman\Test\TestCase;
@@ -60,14 +61,19 @@ class RedeemInvitesTest extends TestCase
 
     /**
      * @test
-     * @expectedException \Clarkeash\Doorman\Exceptions\ExpiredInviteCode
-     * @expectedExceptionMessage The invite code ABCDE has expired.
      */
     public function it_squawks_if_code_has_expired()
     {
+        $validUntil = Carbon::now()->subDay();
+        $this->expectException(ExpiredInviteCode::class);
+        $this->expectExceptionMessage(sprintf(
+            'The invite code ABCDE has expired, expired on %s.',
+            $validUntil->format(ExpiredInviteCode::DATE_FORMAT)
+        ));
+
         Invite::forceCreate([
             'code' => 'ABCDE',
-            'valid_until' => Carbon::now()->subDay(),
+            'valid_until' => $validUntil,
         ]);
 
         Doorman::redeem('ABCDE');


### PR DESCRIPTION
If you're returning the message straight to the user might be helpful to know when it expired.