### PR TITLE
Allow a custom model to be used

### DIFF
--- a/resources/config/doorman.php
+++ b/resources/config/doorman.php
@@ -11,6 +11,18 @@ return [
     'invite_table_name' => 'invites',
 
     /*
+     |--------------------------------------------------------------------------
+     | Invite Model Class
+     |--------------------------------------------------------------------------
+     |
+     | This option allows you to override the default model.
+     | Your model MUST extend the base Invite model.
+     |
+     | Default: Clarkeash\Doorman\Models\Invite::class
+     */
+    'invite_model' => Clarkeash\Doorman\Models\Invite::class,
+
+    /*
     |--------------------------------------------------------------------------
     | Default Code Generator
     |--------------------------------------------------------------------------
@@ -33,7 +45,7 @@ return [
     |
     */
     'basic' => [
-        'length' => 5
+        'length' => 5,
     ],
 
     /*
@@ -48,7 +60,6 @@ return [
     */
     'uuid' => [
         'version' => 4,
-    ]
+    ],
 
 ];
-

--- a/src/Commands/CleanupCommand.php
+++ b/src/Commands/CleanupCommand.php
@@ -3,7 +3,6 @@
 namespace Clarkeash\Doorman\Commands;
 
 use Illuminate\Console\Command;
-use Clarkeash\Doorman\Models\Invite;
 
 class CleanupCommand extends Command
 {
@@ -28,8 +27,9 @@ class CleanupCommand extends Command
      */
     public function handle()
     {
-        $useless = Invite::useless()->count();
-        Invite::useless()->delete();
+        $modelClass = config('doorman.invite_model');
+        $useless = $modelClass::useless()->count();
+        $modelClass::useless()->delete();
         $this->info('Successfully deleted ' . $useless . ' expired invites from the database.');
     }
 }

--- a/src/Doorman.php
+++ b/src/Doorman.php
@@ -71,7 +71,8 @@ class Doorman
     protected function lookupInvite($code): Invite
     {
         try {
-            return Invite::where('code', '=', Str::upper($code))->firstOrFail();
+            $modelClass = config('doorman.invite_model');
+            return $modelClass::where('code', '=', Str::upper($code))->firstOrFail();
         } catch (ModelNotFoundException $e) {
             throw new InvalidInviteCode(trans('doorman::messages.invalid', [ 'code' => $code ]));
         }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -56,7 +56,9 @@ class Generator
      */
     public function for(string $email)
     {
-        if (Invite::where('for', strtolower($email))->first()) {
+        $modelClass = config('doorman.invite_model');
+
+        if ($modelClass::where('for', strtolower($email))->first()) {
             throw new DuplicateException('You cannot create more than 1 invite code for an email');
         }
 
@@ -94,7 +96,9 @@ class Generator
      */
     protected function build(): Invite
     {
-        $invite = new Invite;
+        $modelClass = config('doorman.invite_model');
+
+        $invite = new $modelClass();
         $invite->code = Str::upper($this->manager->code());
         $invite->for = $this->email;
         $invite->max = $this->uses;

--- a/tests/Feature/CustomModelTest.php
+++ b/tests/Feature/CustomModelTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Clarkeash\Doorman\Test\Feature;
+
+use Doorman;
+use Clarkeash\Doorman\Test\TestCase;
+use Clarkeash\Doorman\Test\TestCustomModel;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+
+class CustomModelTest extends TestCase
+{
+    use DatabaseMigrations;
+
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+        $app['config']->set('doorman.invite_model', TestCustomModel::class);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_use_a_custom_model()
+    {
+        $invites = Doorman::generate()->make();
+
+        $this->assertEquals(TestCustomModel::class, get_class($invites->first()));
+    }
+}

--- a/tests/TestCustomModel.php
+++ b/tests/TestCustomModel.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Clarkeash\Doorman\Test;
+
+use Clarkeash\Doorman\Models\Invite;
+
+class TestCustomModel extends Invite
+{ }


### PR DESCRIPTION
I am currently developing a multi-tenant app, so I need to add a relationship to the Invite model to connect an invite to a specific tenant.

This was highly inspired by the way Spatie allows a custom model for (most of) their packages.