### PR TITLE
Allow UUID v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "require": {
     "php": "^7.2.5",
     "laravel/framework": "^7.0",
-    "ramsey/uuid": "^3.6"
+    "ramsey/uuid": "^3.6|^4.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
In the future, we may need to move to using `UuidFactory` since it looks like they changed the `Uuid` class to be a wrapper for the factory but for now it works with both v3 and v4.