### PR TITLE
Add support for Laravel 9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,19 +17,8 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.3, 7.4, 8.0, 8.1]
-        laravel: [8.*, 9.*]
+        php: [8.0, 8.1]
         stability: [prefer-lowest, prefer-stable]
-        include:
-          - laravel: 9.*
-            testbench: 7.*
-          - laravel: 8.*
-            testbench: ^6.23
-        exclude:
-          - laravel: 9.*
-            php: 7.4
-          - laravel: 9.*
-            php: 7.3
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -51,9 +40,7 @@ jobs:
           coverage: xdebug
 
       - name: Install dependencies
-        run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+        run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests
         run: vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,8 +17,19 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.3, 7.4, 8.0]
+        php: [7.3, 7.4, 8.0, 8.1]
+        laravel: [8.*, 9.*]
         stability: [prefer-lowest, prefer-stable]
+        include:
+          - laravel: 9.*
+            testbench: 7.*
+          - laravel: 8.*
+            testbench: ^6.23
+        exclude:
+          - laravel: 9.*
+            php: 7.4
+          - laravel: 9.*
+            php: 7.3
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -26,7 +37,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Cache dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.composer/cache/files
           key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
@@ -40,7 +51,9 @@ jobs:
           coverage: xdebug
 
       - name: Install dependencies
-        run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests
         run: vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "require": {
     "php": "^7.3|^8.0",
-    "laravel/framework": "^8.0",
+    "laravel/framework": "^9.0",
     "ramsey/uuid": "^4.0"
   },
   "autoload": {
@@ -24,7 +24,7 @@
     }
   },
   "require-dev": {
-    "orchestra/testbench": "^6.0",
+    "orchestra/testbench": "^6.0|^7.0",
     "phpunit/phpunit": "^9.3",
     "mockery/mockery": "^1.4"
   },
@@ -40,5 +40,7 @@
   },
   "config": {
     "preferred-install": "dist"
-  }
+  },
+  "minimum-stability": "dev",
+  "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     }
   ],
   "require": {
-    "php": "^7.3|^8.0",
+    "php": "^8.0",
     "laravel/framework": "^9.0",
     "ramsey/uuid": "^4.0"
   },
@@ -24,7 +24,7 @@
     }
   },
   "require-dev": {
-    "orchestra/testbench": "^6.0|^7.0",
+    "orchestra/testbench": "^7.0",
     "phpunit/phpunit": "^9.3",
     "mockery/mockery": "^1.4"
   },


### PR DESCRIPTION
This PR adds support for Laravel 9.

If you want I can drop old php versions from the test workflow since I guess the new version will only support Laravel 9 (and PHP ^8.0).