### PR TITLE
Laravel 10 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.0, 8.1]
+        php: [8.1]
         stability: [prefer-lowest, prefer-stable]
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/README.md
+++ b/README.md
@@ -32,13 +32,14 @@ Invite Codes:
  7.x      | 5.x
  8.x      | 6.x
  9.x      | 7.x
+ 10.x     | 8.x
 
 ## Installation
 
 You can pull in the package using [composer](https://getcomposer.org):
 
 ```bash
-$ composer require "clarkeash/doorman=^7.0"
+$ composer require "clarkeash/doorman=^8.0"
 ```
 
 Next, migrate the database:

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "require": {
     "php": "^8.0",
-    "laravel/framework": "^9.0",
+    "laravel/framework": "^9.0|^10.0",
     "ramsey/uuid": "^4.0"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
     }
   ],
   "require": {
-    "php": "^8.0",
-    "laravel/framework": "^9.0|^10.0",
+    "php": "^8.1",
+    "laravel/framework": "^10.0",
     "ramsey/uuid": "^4.0"
   },
   "autoload": {
@@ -24,7 +24,7 @@
     }
   },
   "require-dev": {
-    "orchestra/testbench": "^7.0",
+    "orchestra/testbench": "^8.0",
     "phpunit/phpunit": "^9.3",
     "mockery/mockery": "^1.4"
   },


### PR DESCRIPTION
This PR adds support for the upcoming version Laravel 10.

I also removed support for PHP 8.0 since the minimum version required by Laravel 10 is PHP 8.1. This means that this should probably be released as a new major version.

If you plan to merge this I am happy to also update the readme.